### PR TITLE
Changes to run on Google Colab

### DIFF
--- a/Python/runInteractivePokerJN.ipynb
+++ b/Python/runInteractivePokerJN.ipynb
@@ -2,15 +2,49 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "k0x5rHccukIy"
+   },
    "source": [
     "# Quantum poker\n",
-    "This program aims to serve as an introduction to how quantum logic gates operate on qubits, and to basic properties of entanglement and superposition."
+    "This program aims to serve as an introduction to how quantum logic gates operate on qubits, and to basic properties of entanglement and superposition.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "<center><a href=\"https://colab.research.google.com/github/sintefmath/QuantumPoker/blob/master/Python/runInteractivePokerJN.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a></center>\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lT3gb4a0uuSk"
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "  from google.colab import output\n",
+    "  output.enable_custom_widget_manager()\n",
+    "  !pip install qiskit\n",
+    "  !pip install ipympl\n",
+    "  !rm -rf /content/QuantumPoker/\n",
+    "  !git clone https://github.com/sintefmath/QuantumPoker\n",
+    "  sys.path.append('/content/QuantumPoker/Python')\n",
+    "  sys.path.append('/content/QuantumPoker')\n",
+    "  get_ipython().magic('matplotlib ipympl')\n",
+    "else:\n",
+    "  get_ipython().magic('matplotlib notebook')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "LNUDRSquukI7"
+   },
    "source": [
     "## Intro\n",
     "In this quantum version of poker, the players are initially dealt three quantum gates that can be applied to qubits at the end of every game. Each player has their own set of qubits, but all the sets start in the same initial state. The goal is to measure as many $1$’s as possible after applying your gates to the qubits. Therefore, any player who has not folded by the end of a game should apply their gates in such a way that each qubit has a high probability of being in the state $\\vert 1\\rangle$."
@@ -18,7 +52,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "nG1Pr1a3ukI9"
+   },
    "source": [
     "## Playing the game\n",
     "First we need to import the required functions and set up the starting conditions for the game."
@@ -26,11 +62,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "id": "UGzMvr3GukI-"
+   },
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
     "from os.path import dirname, abspath\n",
     "import sys\n",
     "sys.path.append(dirname(abspath('')))\n",
@@ -48,7 +85,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "a2ONh02SukJC"
+   },
    "source": [
     "Then we can create the board. Here you see there are three players, James, Lilly, and Harry. In this round James is small blind and Lilly is big blind, so they have already put money on the table. To the right we can see the gates available in the \"deck\" that the players have been dealt from. For now there are no qubits on the table, as the first three are shown only after the first round of betting. A player can choose to either check/call or fold by pressing the corresponding button or raise by entering a self-determined amount into the text box and hitting the enter button, during their turn. For a more detailed description, please read a guide on poker rules (Texas hold 'em).\n",
     "\n",
@@ -58,8 +97,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "id": "nY2W34-BukJD"
+   },
    "outputs": [],
    "source": [
     "if not count_nonzero(money==0) == (nPlayers-1):\n",
@@ -80,6 +121,10 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "name": "runInteractivePokerJN.ipynb",
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -99,5 +144,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
These changes include a link to open the notebook on Google Colab plus a cell to install the dependencies on Colab's runtime.

The interactive widgets are loading from a separate server and need cross-site cookies enabled.

The link in the notebook points to @sintefmath repo, so it won't work until merged. To check it out without merging, I left a branch pointing to my repo here: https://github.com/DrDub/QuantumPoker/blob/drdub/Python/runInteractivePokerJN.ipynb

